### PR TITLE
Switch release to GitHub org token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,4 @@ jobs:
     - run: python -m twine upload dist/*
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
@amureki I added a token to the org, to make it easier for people to open source our software:
https://github.com/organizations/voiio/settings/secrets/actions

Maybe you switch emark to this token too.