### PR TITLE
Add persistent schedule using redis jobstore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           - 6379:6379
         options: --entrypoint redis-server
     env:
-      REDIS_URL: redis://localhost/0
+      REDIS_URL: redis:///0
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -38,10 +38,15 @@ Finally, you lauch the scheduler in a separate process:
 python3 manage.py crontab
 ```
 
-### Setup Redis as a lock backend (optional)
+### Setup Redis as a lock backend and persistent schedule (optional)
 
 If you use Redis as a broker, you can use Redis as a lock backend as well.
-The lock backend is used to prevent multiple instances of the scheduler from running at the same time.
+The lock backend is used to prevent multiple instances of the scheduler
+from running at the same time. This is important if you have multiple
+instances of your application running.
+
+You can also use Redis as a persistent schedule backend. This is useful
+if you want to keep the schedule between restarts of the scheduler.
 
 ```python
 # settings.py

--- a/dramatiq_crontab/__init__.py
+++ b/dramatiq_crontab/__init__.py
@@ -5,6 +5,7 @@ from apscheduler.triggers.cron import CronTrigger
 from django.utils import timezone
 
 from . import _version
+from .utils import jobstores
 
 try:
     from sentry_sdk.crons import monitor
@@ -18,7 +19,7 @@ VERSION = _version.version_tuple
 __all__ = ["cron", "scheduler"]
 
 
-scheduler = BlockingScheduler()
+scheduler = BlockingScheduler(jobstores=jobstores)
 
 
 def cron(schedule):

--- a/dramatiq_crontab/utils.py
+++ b/dramatiq_crontab/utils.py
@@ -1,0 +1,33 @@
+from dramatiq_crontab.conf import get_settings
+
+if redis_url := get_settings().REDIS_URL:
+    import redis
+    from apscheduler.jobstores.redis import RedisJobStore
+    from redis.exceptions import LockError  # noqa
+
+    redis_client = redis.Redis.from_url(redis_url)
+    lock = redis_client.lock("dramatiq-scheduler", blocking_timeout=0)
+
+    jobstores = {
+        "default": RedisJobStore(
+            connection_pool=redis.ConnectionPool.from_url(get_settings().REDIS_URL)
+        )
+    }
+
+
+else:
+
+    class FakeLock:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class LockError(Exception):
+        pass
+
+    jobstores = {}
+    lock = FakeLock()
+
+__all__ = ["LockError", "lock", "jobstores"]

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -85,7 +85,12 @@ DATABASES = {
     }
 }
 
-DRAMATIQ_CRONTAB = {"REDIS_URL": os.getenv("REDIS_URL", "redis://localhost:6379/0")}
+try:
+    import redis  # noqa
+except ImportError:
+    pass
+else:
+    DRAMATIQ_CRONTAB = {"REDIS_URL": os.getenv("REDIS_URL", "redis:///0")}
 
 dramatiq.set_broker(StubBroker())
 


### PR DESCRIPTION
You can also use Redis as a persistent schedule backend. This is useful
if you want to keep the schedule between restarts of the scheduler.