### PR TITLE
Fix #40 -- Add lock timeout and extend it while running to avoid deadlocks

### DIFF
--- a/dramatiq_crontab/conf.py
+++ b/dramatiq_crontab/conf.py
@@ -9,6 +9,9 @@ def get_settings():
         (),
         {
             "REDIS_URL": None,
+            "LOCK_REFRESH_INTERVAL": 5,
+            "LOCK_TIMEOUT": 10,
+            "LOCK_BLOCKING_TIMEOUT": 15,
             **getattr(settings, "DRAMATIQ_CRONTAB", {}),
         },
     )

--- a/dramatiq_crontab/management/commands/crontab.py
+++ b/dramatiq_crontab/management/commands/crontab.py
@@ -56,6 +56,8 @@ class Command(BaseCommand):
     def launch_scheduler(self):
         signal.signal(signal.SIGTERM, kill_softly)
         self.stdout.write(self.style.SUCCESS("Starting scheduler…"))
+        # Periodically extend TTL of lock if needed
+        # https://redis-py.readthedocs.io/en/stable/lock.html#redis.lock.Lock.extend
         scheduler.add_job(
             utils.lock.extend,
             IntervalTrigger(seconds=conf.get_settings().LOCK_REFRESH_INTERVAL),

--- a/dramatiq_crontab/utils.py
+++ b/dramatiq_crontab/utils.py
@@ -1,23 +1,32 @@
 from dramatiq_crontab.conf import get_settings
 
+__all__ = ["LockError", "lock"]
+
+
+class FakeLock:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def extend(self, additional_time=None, replace_ttl=False):
+        pass
+
+
 if redis_url := get_settings().REDIS_URL:
     import redis
     from redis.exceptions import LockError  # noqa
 
     redis_client = redis.Redis.from_url(redis_url)
-    lock = redis_client.lock("dramatiq-scheduler", blocking_timeout=0)
+    lock = redis_client.lock(
+        "dramatiq-scheduler",
+        blocking_timeout=get_settings().LOCK_BLOCKING_TIMEOUT,
+        timeout=get_settings().LOCK_TIMEOUT,
+    )
 else:
-
-    class FakeLock:
-        def __enter__(self):
-            pass
-
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            pass
 
     class LockError(Exception):
         pass
 
     lock = FakeLock()
-
-__all__ = ["LockError", "lock"]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 import pytest
 from django.core.management import call_command
 
-import dramatiq_crontab.utils
+from dramatiq_crontab import utils
 from dramatiq_crontab.management.commands import crontab
 
 
@@ -40,11 +40,24 @@ class TestCrontab:
             assert "Scheduling heartbeat." not in stdout.getvalue()
 
     def test_locked(self):
+        """A lock was already acquired by another process."""
         pytest.importorskip("redis", reason="redis is not installed")
-        with dramatiq_crontab.utils.lock:
+        with utils.redis_client.lock("dramatiq-scheduler", blocking_timeout=0):
             with io.StringIO() as stderr:
                 call_command("crontab", stderr=stderr)
                 assert "Another scheduler is already running." in stderr.getvalue()
+
+    def test_locked_no_refresh(self, monkeypatch):
+        """A lock was acquired, but it was not refreshed."""
+        pytest.importorskip("redis", reason="redis is not installed")
+        scheduler = Mock()
+        monkeypatch.setattr(crontab, "scheduler", scheduler)
+        utils.redis_client.lock(
+            "dramatiq-scheduler", blocking_timeout=0, timeout=1
+        ).acquire()
+        with io.StringIO() as stdout:
+            call_command("crontab", stdout=stdout)
+            assert "Starting scheduler…" in stdout.getvalue()
 
     def test_handle(self, monkeypatch):
         scheduler = Mock()

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -86,12 +86,18 @@ DATABASES = {
     }
 }
 
+DRAMATIQ_CRONTAB = {
+    "LOCK_REFRESH_INTERVAL": 1,
+    "LOCK_TIMEOUT": 2,
+    "LOCK_BLOCKING_TIMEOUT": 3,
+}
+
 try:
     import redis  # noqa
 except ImportError:
     pass
 else:
-    DRAMATIQ_CRONTAB = {"REDIS_URL": os.getenv("REDIS_URL", "redis:///0")}
+    DRAMATIQ_CRONTAB["REDIS_URL"] = os.getenv("REDIS_URL", "redis:///0")
 
 dramatiq.set_broker(StubBroker())
 


### PR DESCRIPTION
Set a lock time out and extend the timeout periodically before it can expire.
This way, a working scheduler will maintain a lock, while a broken one will release it.

We also wait longer than the timeout (without it being extended) while acquiring a lock.
Therefore, a daemon recovering from an ungraceful shutdown will be able to recover. 