### PR TITLE
Add basic interval support (`@interval` decorator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,32 @@ def my_task():
     my_task.logger.info("Hello World")
 ```
 
+### Interval
+
+If you want to run a task more frequently than once a minute, you can use the
+`interval` decorator.
+
+```python
+# tasks.py
+import dramatiq
+from dramatiq_crontab import interval
+
+
+@interval(seconds=30)
+@dramatiq.actor
+def my_task():
+    my_task.logger.info("Hello World")
+```
+
+Please note that the interval is relative to the time the scheduler is started.
+For example, if you start the scheduler at 12:00:00, the first run will be at
+12:00:30. However, if you restart the scheduler at 12:00:15, the first run will
+be at 12:00:45.
+
 ### Sentry Cron Monitors
 
 If you use [Sentry][sentry] you can add cron monitors to your tasks.
 The monitor's slug will be the actor's name. Like `my_task` in the example above.
-
 
 ### The crontab command
 

--- a/dramatiq_crontab/__init__.py
+++ b/dramatiq_crontab/__init__.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 from apscheduler.schedulers.base import STATE_STOPPED
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
 from django.utils import timezone
 
 from . import _version
@@ -17,7 +18,7 @@ except ImportError:
 __version__ = _version.version
 VERSION = _version.version_tuple
 
-__all__ = ["cron", "scheduler"]
+__all__ = ["cron", "interval", "scheduler"]
 
 
 class LazyBlockingScheduler(BlockingScheduler):
@@ -78,6 +79,41 @@ def cron(schedule):
         )
         # We don't add the Sentry monitor on the actor itself, because we only want to
         # monitor the cron job, not the actor itself, or it's direct invocations.
+        return actor
+
+    return decorator
+
+
+def interval(*, seconds):
+    """
+    Run task on a periodic interval.
+
+    Usage:
+        @interval(seconds=30)
+        @dramatiq.actor
+        def interval_test():
+            print("Interval test")
+
+    Please note that the interval is relative to the time the scheduler is started. For
+    example, if you start the scheduler at 12:00:00, the first run will be at 12:00:30.
+    However, if you restart the scheduler at 12:00:15, the first run will be at
+    12:00:45.
+
+    For an interval that is consistent with the clock, use the `cron` decorator instead.
+    """
+
+    def decorator(actor):
+        if monitor is not None:
+            actor.fn = monitor(actor.actor_name)(actor.fn)
+
+        scheduler.add_job(
+            actor.send,
+            IntervalTrigger(
+                seconds=seconds,
+                timezone=timezone.get_default_timezone(),
+            ),
+            name=actor.actor_name,
+        )
         return actor
 
     return decorator

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,7 +6,7 @@ except ImportError:
     from backports import zoneinfo
 
 import pytest
-from dramatiq_crontab import scheduler, tasks
+from dramatiq_crontab import scheduler, tasks, interval
 
 
 def test_heartbeat(caplog):
@@ -87,4 +87,15 @@ def test_cron__error(schedule):
     assert (
         "Please use a literal day of week (Mon, Tue, Wed, Thu, Fri, Sat, Sun) or *"
         in str(e.value)
+    )
+
+
+def test_interval__seconds():
+    assert not scheduler.remove_all_jobs()
+    assert interval(seconds=30)(tasks.heartbeat)
+    init = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    assert scheduler.get_jobs()[0].trigger.get_next_fire_time(
+        init, init
+    ) == datetime.datetime(
+        2021, 1, 1, 0, 0, 30, tzinfo=zoneinfo.ZoneInfo(key="Europe/Berlin")
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -6,7 +6,7 @@ except ImportError:
     from backports import zoneinfo
 
 import pytest
-from dramatiq_crontab import scheduler, tasks, interval
+from dramatiq_crontab import interval, scheduler, tasks
 
 
 def test_heartbeat(caplog):


### PR DESCRIPTION
As discussed in #103, this PR adds simple interval scheduling via `@interval(seconds=...)` decorator.

I kept the interface minimal, supporting only the `seconds` parameter. This should handle the most common use cases without overlapping functionality provided by the more intuitive `@cron` decorator.

See updated README for usage details.