### PR TITLE
Fix handling when lock cannot be extended

### DIFF
--- a/dramatiq_crontab/conf.py
+++ b/dramatiq_crontab/conf.py
@@ -12,6 +12,7 @@ def get_settings():
             "LOCK_REFRESH_INTERVAL": 5,
             "LOCK_TIMEOUT": 10,
             "LOCK_BLOCKING_TIMEOUT": 15,
+            "LOCK_AUTORETRY": False,
             **getattr(settings, "DRAMATIQ_CRONTAB", {}),
         },
     )

--- a/dramatiq_crontab/management/commands/crontab.py
+++ b/dramatiq_crontab/management/commands/crontab.py
@@ -1,11 +1,14 @@
 import importlib
 import signal
+import time
 
 from apscheduler.triggers.interval import IntervalTrigger
 from django.apps import apps
 from django.core.management import BaseCommand
 
 from ... import conf, utils
+
+settings = conf.get_settings()
 
 try:
     from sentry_sdk import capture_exception
@@ -44,27 +47,39 @@ class Command(BaseCommand):
         if not options["no_heartbeat"]:
             importlib.import_module("dramatiq_crontab.tasks")
             self.stdout.write("Scheduling heartbeat.")
-        try:
-            if not isinstance(utils.lock, utils.FakeLock):
-                self.stdout.write("Acquiring lock…")
-            # Lock scheduler to prevent multiple instances from running.
-            with utils.lock:
-                self.launch_scheduler()
-        except utils.LockError as e:
-            capture_exception(e)
-            self.stderr.write("Another scheduler is already running.")
+        autoretry = settings.LOCK_AUTORETRY
+        while True:
+            try:
+                if not isinstance(utils.lock, utils.FakeLock):
+                    self.stdout.write("Acquiring lock…")
+                with utils.lock:
+                    self.launch_scheduler()
+                return  # graceful stop
+            except utils.LockError:
+                if not autoretry:
+                    raise
+                self.stderr.write("Failed to acquire or lost lock – retrying…")
+                time.sleep(settings.LOCK_REFRESH_INTERVAL)
 
     def launch_scheduler(self):
         signal.signal(signal.SIGHUP, kill_softly)
         signal.signal(signal.SIGTERM, kill_softly)
         signal.signal(signal.SIGINT, kill_softly)
         self.stdout.write(self.style.SUCCESS("Starting scheduler…"))
-        # Periodically extend TTL of lock if needed
-        # https://redis-py.readthedocs.io/en/stable/lock.html#redis.lock.Lock.extend
+        self._lost_lock_exc = None
+
+        def _extend_lock():
+            try:
+                utils.lock.extend(settings.LOCK_TIMEOUT, replace_ttl=True)
+            except utils.LockError as exc:
+                self._lost_lock_exc = exc
+                scheduler.shutdown(wait=False)
+
         scheduler.add_job(
-            utils.lock.extend,
-            IntervalTrigger(seconds=conf.get_settings().LOCK_REFRESH_INTERVAL),
-            args=(conf.get_settings().LOCK_TIMEOUT, True),
+            _extend_lock,
+            IntervalTrigger(seconds=settings.LOCK_REFRESH_INTERVAL),
+            id="dramatiq_crontab_lock_extend",
+            replace_existing=True,
             name="dramatiq_crontab.utils.lock.extend",
         )
         try:
@@ -73,6 +88,8 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING(str(e)))
             self.stdout.write(self.style.NOTICE("Shutting down scheduler…"))
             scheduler.shutdown()
+        if self._lost_lock_exc:
+            raise self._lost_lock_exc
 
     def load_tasks(self, options):
         """


### PR DESCRIPTION
* Prevents the scheduler from continuing after a lost Redis lock (see #118)
* Adds `LOCK_AUTORETRY` (default **`False`**)  
  * `False` → behave like before: exit on any `LockError`.  
  * `True`  → automatically retry acquiring the lock and restart the scheduler.