### PR TITLE
Fix #125 -- Shutdown scheduler if lock fails

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,7 +18,7 @@ class TestCrontab:
     def patch_launch(self, monkeypatch):
         monkeypatch.setattr(
             "dramatiq_crontab.management.commands.crontab.Command.launch_scheduler",
-            lambda s: None,
+            lambda *args, **kwargs: None,
         )
 
     def test_default(self, patch_launch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock
+
+import pytest
+from dramatiq_crontab import utils
+
+
+def test_extend_lock():
+    lock = Mock()
+    scheduler = Mock()
+    utils.extend_lock(lock, scheduler)
+    assert lock.extend.call_count == 1
+    assert scheduler.shutdown.call_count == 0
+
+
+def test_extend_lock__error():
+    lock = Mock()
+    lock.extend.side_effect = utils.LockError()
+    scheduler = Mock()
+    with pytest.raises(utils.LockError):
+        utils.extend_lock(lock, scheduler)
+    assert lock.extend.call_count == 1
+    assert scheduler.shutdown.call_count == 1


### PR DESCRIPTION
### how to test

1. Install the patched version
2. Do a `FLUSHALL` on the correct logical REDIS db