### PR TITLE
issues/130

### DIFF
--- a/dramatiq_crontab/utils.py
+++ b/dramatiq_crontab/utils.py
@@ -5,7 +5,7 @@ __all__ = ["LockError", "lock"]
 
 class FakeLock:
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass

--- a/dramatiq_crontab/utils.py
+++ b/dramatiq_crontab/utils.py
@@ -11,7 +11,7 @@ class FakeLock:
         pass
 
     def extend(self, additional_time=None, replace_ttl=False):
-        pass
+        return True
 
 
 if redis_url := get_settings().REDIS_URL:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,3 +20,17 @@ def test_extend_lock__error():
         utils.extend_lock(lock, scheduler)
     assert lock.extend.call_count == 1
     assert scheduler.shutdown.call_count == 1
+
+
+class TestFakeLock:
+    def test_enter(self):
+        fake_lock = utils.FakeLock()
+        assert fake_lock.__enter__() is fake_lock
+
+    def test_exit(self):
+        fake_lock = utils.FakeLock()
+        assert fake_lock.__exit__(None, None, None) is None
+
+    def test_extend(self):
+        fake_lock = utils.FakeLock()
+        assert fake_lock.extend(additional_time=10, replace_ttl=True)


### PR DESCRIPTION
- **Bump ruff from 0.12.0 to 0.12.1 (#127)**
- **Bump ruff from 0.12.1 to 0.12.2 (#128)**
- **Bump ruff from 0.12.2 to 0.12.3 (#129)**
- **Fix #125 -- Shutdown scheduler if lock fails**
- **Fix AttributeError due to buggy FakeLock class**
- **Add tests**
