### PR TITLE
Auto-upsert Sentry cron monitors via `monitor_config`

### DIFF
--- a/dramatiq_crontab/__init__.py
+++ b/dramatiq_crontab/__init__.py
@@ -75,9 +75,9 @@ def cron(schedule):
                 "schedule": {"type": "crontab", "value": schedule},
                 "timezone": str(timezone.get_default_timezone()),
             }
-            actor.fn = monitor(
-                actor.actor_name, monitor_config=monitor_config
-            )(actor.fn)
+            actor.fn = monitor(actor.actor_name, monitor_config=monitor_config)(
+                actor.fn
+            )
 
         scheduler.add_job(
             actor.send,

--- a/dramatiq_crontab/__init__.py
+++ b/dramatiq_crontab/__init__.py
@@ -36,6 +36,15 @@ class LazyBlockingScheduler(BlockingScheduler):
 scheduler = LazyBlockingScheduler()
 
 
+def _interval_schedule(seconds):
+    """Convert an interval in seconds to a Sentry monitor schedule, if expressible."""
+    # Sentry also supports week/month/year, omitted as unrealistic for dramatiq intervals.
+    for unit, size in (("day", 86400), ("hour", 3600), ("minute", 60)):
+        if seconds >= size and seconds % size == 0:
+            return {"type": "interval", "value": seconds // size, "unit": unit}
+    return None
+
+
 def cron(schedule):
     """
     Run task on a scheduler with a cron schedule.
@@ -46,13 +55,8 @@ def cron(schedule):
         def cron_test():
             print("Cron test")
 
-
-    Please don't forget to set up a sentry monitor for the actor, otherwise you won't
-    get any notifications if the cron job fails.
-
-    The monitor slug is your actor name, the schedule should be set to the same
-    cron schedule as the cron decorator. The schedule type should be set to cron.
-    The monitors timezone should be set to Europe/Berlin.
+    If ``sentry-sdk`` is installed, a Sentry cron monitor is automatically
+    upserted on the first check-in using the actor name as the monitor slug.
     """
 
     def decorator(actor):
@@ -67,7 +71,13 @@ def cron(schedule):
             )
 
         if monitor is not None:
-            actor.fn = monitor(actor.actor_name)(actor.fn)
+            monitor_config = {
+                "schedule": {"type": "crontab", "value": schedule},
+                "timezone": str(timezone.get_default_timezone()),
+            }
+            actor.fn = monitor(
+                actor.actor_name, monitor_config=monitor_config
+            )(actor.fn)
 
         scheduler.add_job(
             actor.send,
@@ -100,11 +110,23 @@ def interval(*, seconds):
     12:00:45.
 
     For an interval that is consistent with the clock, use the `cron` decorator instead.
+
+    If ``sentry-sdk`` is installed, a Sentry cron monitor is automatically
+    upserted on the first check-in using the actor name as the monitor slug.
+    Sub-minute intervals skip the auto-upsert (Sentry's smallest unit is minute)
+    and fall back to check-ins only.
     """
 
     def decorator(actor):
         if monitor is not None:
-            actor.fn = monitor(actor.actor_name)(actor.fn)
+            monitor_kwargs = {}
+            schedule = _interval_schedule(seconds)
+            if schedule is not None:
+                monitor_kwargs["monitor_config"] = {
+                    "schedule": schedule,
+                    "timezone": str(timezone.get_default_timezone()),
+                }
+            actor.fn = monitor(actor.actor_name, **monitor_kwargs)(actor.fn)
 
         scheduler.add_job(
             actor.send,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,7 @@
 import datetime
+from unittest import mock
 
+import dramatiq_crontab
 import pytest
 from django.utils.timezone import make_aware
 from dramatiq_crontab import interval, scheduler, tasks
@@ -83,3 +85,74 @@ def test_interval__seconds():
     assert scheduler.get_jobs()[0].trigger.get_next_fire_time(init, init) == make_aware(
         datetime.datetime(2021, 1, 1, 0, 0, 30)
     )
+
+
+def _fake_monitor():
+    fake = mock.MagicMock()
+    fake.return_value = lambda fn: fn
+    return fake
+
+
+def test_cron__sentry_monitor_config(monkeypatch):
+    assert not scheduler.remove_all_jobs()
+    fake = _fake_monitor()
+    monkeypatch.setattr(dramatiq_crontab, "monitor", fake)
+    tasks.cron("0 2 * * *")(tasks.heartbeat)
+    fake.assert_called_once()
+    args, kwargs = fake.call_args
+    assert args == (tasks.heartbeat.actor_name,)
+    assert kwargs["monitor_config"]["schedule"] == {
+        "type": "crontab",
+        "value": "0 2 * * *",
+    }
+    assert kwargs["monitor_config"]["timezone"]
+
+
+def test_interval__sentry_monitor_config_minute(monkeypatch):
+    assert not scheduler.remove_all_jobs()
+    fake = _fake_monitor()
+    monkeypatch.setattr(dramatiq_crontab, "monitor", fake)
+    interval(seconds=300)(tasks.heartbeat)
+    fake.assert_called_once()
+    _, kwargs = fake.call_args
+    assert kwargs["monitor_config"]["schedule"] == {
+        "type": "interval",
+        "value": 5,
+        "unit": "minute",
+    }
+
+
+def test_interval__sentry_monitor_config_hour(monkeypatch):
+    assert not scheduler.remove_all_jobs()
+    fake = _fake_monitor()
+    monkeypatch.setattr(dramatiq_crontab, "monitor", fake)
+    interval(seconds=3600)(tasks.heartbeat)
+    fake.assert_called_once()
+    _, kwargs = fake.call_args
+    assert kwargs["monitor_config"]["schedule"] == {
+        "type": "interval",
+        "value": 1,
+        "unit": "hour",
+    }
+
+
+def test_interval__sentry_no_config_for_sub_minute(monkeypatch):
+    assert not scheduler.remove_all_jobs()
+    fake = _fake_monitor()
+    monkeypatch.setattr(dramatiq_crontab, "monitor", fake)
+    interval(seconds=30)(tasks.heartbeat)
+    fake.assert_called_once()
+    _, kwargs = fake.call_args
+    assert "monitor_config" not in kwargs
+
+
+def test_cron__sentry_not_installed(monkeypatch):
+    assert not scheduler.remove_all_jobs()
+    monkeypatch.setattr(dramatiq_crontab, "monitor", None)
+    assert tasks.cron("0 2 * * *")(tasks.heartbeat)
+
+
+def test_interval__sentry_not_installed(monkeypatch):
+    assert not scheduler.remove_all_jobs()
+    monkeypatch.setattr(dramatiq_crontab, "monitor", None)
+    assert interval(seconds=30)(tasks.heartbeat)


### PR DESCRIPTION
Some time ago, Sentry introduced an ability to automatically create cron monitors in case the monitor config is provided along with the payload:
https://docs.sentry.io/platforms/python/crons/#configuring-cron-monitors

I find it convenient and worth implementing in this library.

I wonder if, for better UX, we want to make this optional or to allow users to provide extra configuration options along with the check. But honestly, Sentry has sensible defaults that can be easily changed along the way. It's better to create a cron monitor with a suboptimal configuration rather than to forget about one.